### PR TITLE
Install rubygems and ghi

### DIFF
--- a/onsite-testing/Dockerfile
+++ b/onsite-testing/Dockerfile
@@ -4,10 +4,13 @@ USER ubuntu
 WORKDIR /home/ubuntu
 
 RUN sudo apt-get update && sudo apt-get install -y \
-    nodejs
+    nodejs \
+    rubygems
 
 RUN curl -O https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
 RUN tar xf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
 RUN sudo cp phantomjs /usr/local/bin/phantomjs
+
+RUN sudo gem install ghi
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This PR adds the `ghi` gem to the `onsite-testing` image, which allows coverage reports to be posted to pull requests automatically.
