### PR TITLE
Add python2.7 and 3.4 based images with more packages

### DIFF
--- a/obsrvbl-2.7/Dockerfile
+++ b/obsrvbl-2.7/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -O https://s3.amazonaws.com/onstatic/site-packages/nfdump-1.6.14-x86_64
 RUN mv nfdump-1.6.14-x86_64 /usr/bin/nfdump
 RUN chmod +x /usr/bin/nfdump
 
-RUN pip install -U 'pip>=1.5.6' 'setuptools>=18.6.1'
+RUN pip install -U 'pip>=6.0' 'setuptools>=18.6.1'
 
 RUN gem install ghi
 

--- a/obsrvbl-2.7/Dockerfile
+++ b/obsrvbl-2.7/Dockerfile
@@ -17,6 +17,11 @@ RUN apt-get update && apt-get install -y \
 RUN curl -O https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
 RUN tar xf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
 RUN cp phantomjs /usr/local/bin/phantomjs
+
+RUN curl -O https://s3.amazonaws.com/onstatic/site-packages/nfdump-1.6.14-x86_64
+RUN mv nfdump-1.6.14-x86_64 /usr/bin/nfdump
+RUN chmod +x /usr/bin/nfdump
+
 RUN pip install -U 'pip>=1.5.6' 'setuptools>=18.6.1'
 
 RUN gem install ghi

--- a/obsrvbl-2.7/Dockerfile
+++ b/obsrvbl-2.7/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:2.7
+MAINTAINER Observable Networks <engineering@obsrvbl.com>
+
+RUN apt-get update && apt-get install -y \
+    nodejs \
+    rubygems \
+    byacc \
+    gfortran \
+    libblas-dev \
+    liblapack-dev \
+    libffi-dev \
+    libssl-dev \
+    wamerican \
+    tshark \
+    postgresql-client
+
+RUN curl -O https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+RUN tar xf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+RUN cp phantomjs /usr/local/bin/phantomjs
+RUN pip install -U 'pip>=1.5.6' 'setuptools>=18.6.1'
+
+RUN gem install ghi
+
+ENTRYPOINT ["/bin/bash"]

--- a/obsrvbl-3.4/Dockerfile
+++ b/obsrvbl-3.4/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -O https://s3.amazonaws.com/onstatic/site-packages/nfdump-1.6.14-x86_64
 RUN mv nfdump-1.6.14-x86_64 /usr/bin/nfdump
 RUN chmod +x /usr/bin/nfdump
 
-RUN pip install -U 'pip>=1.5.6' 'setuptools>=18.6.1'
+RUN pip install -U 'pip>=6.0' 'setuptools>=18.6.1'
 
 RUN gem install ghi
 

--- a/obsrvbl-3.4/Dockerfile
+++ b/obsrvbl-3.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.4
+MAINTAINER Observable Networks <engineering@obsrvbl.com>
+
+RUN apt-get update && apt-get install -y \
+    nodejs \
+    rubygems \
+    byacc \
+    gfortran \
+    libblas-dev \
+    liblapack-dev \
+    libffi-dev \
+    libssl-dev \
+    wamerican \
+    tshark \
+    postgresql-client
+
+RUN curl -O https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+RUN tar xf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+RUN cp phantomjs /usr/local/bin/phantomjs
+RUN pip install -U 'pip>=1.5.6' 'setuptools>=18.6.1'
+
+RUN gem install ghi
+
+ENTRYPOINT ["/bin/bash"]

--- a/obsrvbl-3.4/Dockerfile
+++ b/obsrvbl-3.4/Dockerfile
@@ -17,6 +17,11 @@ RUN apt-get update && apt-get install -y \
 RUN curl -O https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
 RUN tar xf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
 RUN cp phantomjs /usr/local/bin/phantomjs
+
+RUN curl -O https://s3.amazonaws.com/onstatic/site-packages/nfdump-1.6.14-x86_64
+RUN mv nfdump-1.6.14-x86_64 /usr/bin/nfdump
+RUN chmod +x /usr/bin/nfdump
+
 RUN pip install -U 'pip>=1.5.6' 'setuptools>=18.6.1'
 
 RUN gem install ghi


### PR DESCRIPTION
Not a fan of the duplication but it looks like Docker's automated builds don't really allow for two builds from the same Dockerfile with an environment variable. We could also do a template and generate the Dockerfile.

Ultimately the 3.4 and 2.7 images may end up diverging anyway, so whatever.
