### PR TITLE
Add jansson to the Suricata CentOS images

### DIFF
--- a/suricata-centos-6/Dockerfile
+++ b/suricata-centos-6/Dockerfile
@@ -9,6 +9,7 @@ RUN yum install -y autoconf \
     gcc \
     gcc-c++ \
     git \
+    jansson-devel \
     libcap-ng \
     libcap-ng-devel \
     libnet \

--- a/suricata-centos-7/Dockerfile
+++ b/suricata-centos-7/Dockerfile
@@ -9,6 +9,7 @@ RUN yum install -y autoconf \
     gcc \
     gcc-c++ \
     git \
+    jansson-devel \
     libcap-ng \
     libcap-ng-devel \
     libnet \


### PR DESCRIPTION
`jansson-devel` is needed for EVE log support in [suricata-service](https://github.com/obsrvbl/suricata-service).
