### PR TITLE
More Ruby workarounds for Suricata CentOS images

### DIFF
--- a/suricata-centos-6/Dockerfile
+++ b/suricata-centos-6/Dockerfile
@@ -34,6 +34,7 @@ RUN yum install -y autoconf \
 RUN curl -O https://bootstrap.pypa.io/get-pip.py
 RUN python get-pip.py
 
+RUN gem install json -v 1.8.3
 RUN gem install fpm -v 1.4.0
 
 RUN git clone https://github.com/OISF/libhtp.git

--- a/suricata-centos-7/Dockerfile
+++ b/suricata-centos-7/Dockerfile
@@ -34,7 +34,7 @@ RUN yum install -y autoconf \
 RUN curl -O https://bootstrap.pypa.io/get-pip.py
 RUN python get-pip.py
 
-RUN gem install fpm -v 1.4.0
+RUN gem install fpm
 
 RUN git clone https://github.com/OISF/libhtp.git
 WORKDIR /libhtp


### PR DESCRIPTION
`The command '/bin/sh -c gem install fpm -v 1.4.0' returned a non-zero code: 1`; this pins the `json` Ruby gem.
