### PR TITLE
Update ona-musl-cross image to Alpine 3.6

### DIFF
--- a/ona-musl-cross/Dockerfile
+++ b/ona-musl-cross/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.6
 MAINTAINER Observable Networks <engineering@obsrvbl.com>
 
 # Retrieve Alpine packages
-RUN echo 'http://dl-4.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 RUN apk update && apk add \
     bash \
     bison \
@@ -17,16 +16,17 @@ RUN apk update && apk add \
     python \
     ruby \
     ruby-dev \
+    ruby-irb \
+    ruby-rdoc \
     rpm \
     tar \
     tzdata \
     xz
 
-RUN rc-update add sshd
-
 # Retrieve Python and Ruby packages
 RUN curl -O https://bootstrap.pypa.io/get-pip.py
 RUN python get-pip.py
+RUN pip install awscli
 RUN gem install fpm
 
 # Retrieve libpcap and the cross compilers


### PR DESCRIPTION
This PR switches to the latest release (3.6) of Alpine Linux for the `ona-musl-cross` image.

This release has the `rpm` package in the main repository, so there's no more need to add in `edge`.

It seems there are some more dependencies required to build Ruby gems now, also.

I've also added the `awscli` pip package.